### PR TITLE
add IoT Conn License to repository

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,50 @@
+Licenses for IoT Connectivity Working Group of Open Manufacturing Platform
+
+The following describes the licenses for various materials in this repository.
+For specific details, see the Working Group's Charter, which is available at:
+https://open-manufacturing.org/wp-content/uploads/sites/101/2021/06/OMP-WG-IOT-Connectivity-V-4.0.1-3.3.20-.pdf
+
+Source code in this repository is provided under the MIT License, a copy of
+which is included below.
+
+Materials in this repository other than source code are provided as follows:
+
+Copyright (c) 2021 Joint Development Foundation Projects, LLC, OMP Series and
+its contributors. All rights reserved. THESE MATERIALS ARE PROVIDED "AS IS." The
+owners and contributors expressly disclaim any warranties (express, implied, or
+otherwise), including implied warranties of merchantability, non-infringement,
+fitness for a particular purpose, or title, related to the materials. The entire
+risk as to implementing or otherwise using the materials is assumed by the
+implementer and user. IN NO EVENT WILL THE OWNERS AND CONTRIBUTORS BE LIABLE TO
+ANY OTHER PARTY FOR LOST PROFITS OR ANY FORM OF INDIRECT, SPECIAL, INCIDENTAL,
+OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER FROM ANY CAUSES OF ACTION OF ANY KIND
+WITH RESPECT TO THIS DELIVERABLE OR ITS GOVERNING AGREEMENT, WHETHER BASED ON
+BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), OR OTHERWISE, AND WHETHER OR
+NOT THE OTHER MEMBER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The patent mode selected for materials developed by this Working Group (other
+than source code) is RAND Royalty-Free Mode.
+
+= = = = =
+
+MIT License:
+
+Copyright (c) 2021 Joint Development Foundation Projects, LLC, OMP Series and
+its contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This PR is adding the IoT Connectivity License as indicated in the template repository, https://github.com/OpenManufacturingPlatform/omp-templates-private/blob/development/License/LICENSE-IoT-Connectivity.txt