### PR TITLE
Fixed issues with connection to Milo server

### DIFF
--- a/src/Application/Extensions/HelperExtensions.cs
+++ b/src/Application/Extensions/HelperExtensions.cs
@@ -20,7 +20,7 @@ namespace OMP.Connector.Application.Extensions
             try
             {
                 var uriBuilder = new UriBuilder(endpointUrl);
-                return $"{Constants.OpcTcpPrefix}{uriBuilder.Host}:{uriBuilder.Port}/";
+                return $"{Constants.OpcTcpPrefix}{uriBuilder.Host}:{uriBuilder.Port}{uriBuilder.Path}";
             }
             catch (Exception ex)
             {

--- a/src/Infrastructure/OpcUa/OpcSession.cs
+++ b/src/Infrastructure/OpcUa/OpcSession.cs
@@ -144,6 +144,7 @@ namespace OMP.Connector.Infrastructure.OpcUa
                     var message =
                         $"Unable to create Session to Endpoint with: [{endpointDescription.EndpointUrl}] with SecurityMode: [{endpointDescription.SecurityMode}] and Level: [{endpointDescription.SecurityLevel}] = {e.Message}::{e.InnerException?.Message}";
                     _logger.Warning(message);
+                    await Task.Delay(500); // fix for Milo server not being happy with endpoint connections in quick succession
                 }
             }
 


### PR DESCRIPTION
2 things fixed:

Bug where a path in the endpointurl was removed internally before connecting
Milo seem to not like connections to different endpoints in quick succession - added a 500ms delay between each try