### PR TITLE
Added KeepAliveInterval setting and other cleanup

### DIFF
--- a/src/Application/Application.csproj
+++ b/src/Application/Application.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.368.33" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.368.3-rc0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Domain/Configuration/ConnectorConfiguration.cs
+++ b/src/Domain/Configuration/ConnectorConfiguration.cs
@@ -86,8 +86,9 @@ namespace OMP.Connector.Domain.Configuration
         public int ReadBatchSize { get; set; }
         public int RegisterNodeBatchSize { get; set; }
         public int AwaitSessionLockTimeoutSeconds { get; set; } = 3;
-        public int OperationTimeoutInSeconds { get; set; } = 10;
-        public int ReconnectIntervalInSeconds { get; set; }
+        public int OperationTimeoutInSeconds { get; set; } = 120;
+        public int ReconnectIntervalInSeconds { get; set; } = 10;
+        public int KeepAliveIntervalInSeconds { get; set; } = 5;
 
         public uint NodeMask => (uint)NodeClass.Object |
                                           (uint)NodeClass.Variable |

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -23,7 +23,7 @@
    <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="OneOf" Version="3.0.211" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.368.33" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.368.3-rc0" />
    </ItemGroup>
   
    <ItemGroup>

--- a/src/Infrastructure/OpcUa/ConfigBuilders/AppConfigBuilder.cs
+++ b/src/Infrastructure/OpcUa/ConfigBuilders/AppConfigBuilder.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OMP.Connector.Domain.Configuration;
 using OMP.Connector.Domain.Extensions;
+using OMP.Connector.Infrastructure.OpcUa.Extensions;
 using Opc.Ua;
 
 namespace OMP.Connector.Infrastructure.OpcUa.ConfigBuilders
@@ -64,7 +65,7 @@ namespace OMP.Connector.Infrastructure.OpcUa.ConfigBuilders
             {
                 MaxStringLength = this._opcUaSettings.MaxStringLength,
                 MaxMessageSize = this._opcUaSettings.MaxMessageSize,
-                OperationTimeout = this._opcUaSettings.OperationTimeoutMs
+                OperationTimeout = this._opcUaConfiguration.OperationTimeoutInSeconds.ToMilliseconds()
             };
         }
 

--- a/src/Infrastructure/OpcUa/Extensions/IntervalExtensions.cs
+++ b/src/Infrastructure/OpcUa/Extensions/IntervalExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace OMP.Connector.Infrastructure.OpcUa.Extensions
+{
+    public static class IntervalExtensions
+    {
+        public static int ToMilliseconds(this int seconds)
+            => (int)TimeSpan.FromSeconds(seconds).TotalMilliseconds;
+    }
+}

--- a/src/Infrastructure/OpcUa/OpcSession.cs
+++ b/src/Infrastructure/OpcUa/OpcSession.cs
@@ -22,6 +22,7 @@ using OMP.Connector.Domain.Schema;
 using OMP.Connector.Domain.Schema.Enums;
 using OMP.Connector.Domain.Schema.Interfaces;
 using OMP.Connector.Domain.Schema.Request.Control.WriteValues;
+using OMP.Connector.Infrastructure.OpcUa.Extensions;
 using OMP.Connector.Infrastructure.OpcUa.Reconnect;
 using OMP.Connector.Infrastructure.OpcUa.States;
 using Opc.Ua;
@@ -111,8 +112,9 @@ namespace OMP.Connector.Infrastructure.OpcUa
                     identity,
                     default);
 
+                _session.KeepAliveInterval = _opcUaSettings.KeepAliveIntervalInSeconds.ToMilliseconds();
                 _session.KeepAlive += SessionOnKeepAlive;
-                _session.OperationTimeout = (int)TimeSpan.FromSeconds(_opcUaSettings.OperationTimeoutInSeconds).TotalMilliseconds;
+                _session.OperationTimeout = _opcUaSettings.OperationTimeoutInSeconds.ToMilliseconds();
 
                 await LoadComplexTypeSystemAsync();
 

--- a/src/Infrastructure/OpcUa/OpcUa.csproj
+++ b/src/Infrastructure/OpcUa/OpcUa.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -13,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.4.368.33" />
-    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.4.368.33" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.368.3-rc0" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.5.368.3-rc0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/OpcUa/OpcUaSettings.cs
+++ b/src/Infrastructure/OpcUa/OpcUaSettings.cs
@@ -6,7 +6,7 @@ using Opc.Ua;
 
 namespace OMP.Connector.Infrastructure.OpcUa
 {
-    public record OpcUaSettings //: IOpcUaSettings
+    public record OpcUaSettings
     {
         private const string ModuleName = "OpcUaConnector";
 
@@ -26,25 +26,6 @@ namespace OMP.Connector.Infrastructure.OpcUa
 
         public int MaxMessageSize { get; set; } = 4 * 1024 * 1024;
 
-        public int OperationTimeoutMs { get; set; } = 120000;
-
-        public bool EnableRegisteredNodes { get; set; } = false;
-
-        [Required]
-        public int DefaultServerBrowseDepth { get; set; }
-
-        [Required]
-        public int NodeBrowseDepth { get; set; }
-
-        [Required]
-        public int SubscriptionBatchSize { get; set; } = 1000;
-
-        [Required]
-        public int ReadBatchSize { get; set; } = 1000;
-
-        [Required]
-        public int RegisterNodeBatchSize { get; set; } = 1000;
-
         [Required]
         public string CertificateStoreTypeName { get; set; } = CertificateStoreType.Directory;
 
@@ -60,17 +41,7 @@ namespace OMP.Connector.Infrastructure.OpcUa
         [Required]
         public string OwnCertStorePath { get; set; } = "CurrentUser\\UA_MachineDefault";
 
-        public uint OpcNodeMask => (uint)NodeClass.Object |
-                                   (uint)NodeClass.Variable |
-                                   (uint)NodeClass.Method |
-                                   (uint)NodeClass.VariableType |
-                                   (uint)NodeClass.ReferenceType |
-                                   (uint)NodeClass.Unspecified;
-
         public int OpcStackTraceMask { get; set; } = Utils.TraceMasks.Error | Utils.TraceMasks.Security | Utils.TraceMasks.StackTrace | Utils.TraceMasks.StartStop;
-
-        public int AwaitSessionLockTimeoutSecs { get; set; }
-        public int ReconnectIntervalSecs { get; set; }
 
         #endregion
     }


### PR DESCRIPTION
The latest OPCFoundation nuget package increased the default keepaliveinterval of the session from 5 seconds to 50 seconds.
This causes extremely poor reconnect behaviour and ultimately bad responsiveness of the connector to incoming requests, especially when it has to wait a long time before attempting a reconnect in the case when the session dropped.

By adding the KeepAliveIntervalInSeconds configuration setting, it is possible to override the default of 50 seconds to something more responsive like 5 seconds (the previous default).

Also:
Removed obsolete settings and 
Added default values to some other configuration settings