### PR TITLE
Fixed incorrect initialization of monitored items

### DIFF
--- a/src/Application/Factories/SubscriptionProviderFactory.cs
+++ b/src/Application/Factories/SubscriptionProviderFactory.cs
@@ -21,20 +21,20 @@ namespace OMP.Connector.Application.Factories
         private readonly ISubscriptionRepository _subscriptionRepository;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IOptions<ConnectorConfiguration> _connectorConfiguration;
-        private readonly IOpcMonitoredItemService _monitoredItemService;
+        private readonly IOpcMonitoredItemServiceFactory _monitoredItemServiceFactory;
         private readonly AbstractValidator<SubscriptionMonitoredItem> _monitoredItemValidator;
 
         public SubscriptionProviderFactory(
             ISubscriptionRepository dataManagementService,
             ILoggerFactory loggerFactory,
             IOptions<ConnectorConfiguration> connectorConfiguration,
-            IOpcMonitoredItemService opcMonitoredItemService,
+            IOpcMonitoredItemServiceFactory opcMonitoredItemServiceFactory,
             AbstractValidator<SubscriptionMonitoredItem> monitoredItemValidator)
         {
             this._subscriptionRepository = dataManagementService;
             this._loggerFactory = loggerFactory;
             this._connectorConfiguration = connectorConfiguration;
-            this._monitoredItemService = opcMonitoredItemService;
+            this._monitoredItemServiceFactory = opcMonitoredItemServiceFactory;
             this._monitoredItemValidator = monitoredItemValidator;
         }
 
@@ -52,7 +52,7 @@ namespace OMP.Connector.Application.Factories
                                 this._subscriptionRepository,
                                 this._loggerFactory.CreateLogger<CreateSubscriptionProvider>(),
                                 this._connectorConfiguration,
-                                this._monitoredItemService,
+                                this._monitoredItemServiceFactory,
                                 createCommand,
                                 telemetryMessageMetadata,
                                 this._monitoredItemValidator);

--- a/src/Application/Providers/Subscription/CreateSubscriptionProvider.cs
+++ b/src/Application/Providers/Subscription/CreateSubscriptionProvider.cs
@@ -31,6 +31,7 @@ namespace OMP.Connector.Application.Providers.Subscription
     public class CreateSubscriptionProvider : SubscriptionProvider<CreateSubscriptionsRequest, CreateSubscriptionsResponse>
     {
         private readonly ISubscriptionRepository _subscriptionRepository;
+        private readonly IOpcMonitoredItemServiceFactory opcMonitoredItemServiceFactory;
         private readonly TelemetryMessageMetadata _messageMetadata;
         private readonly AbstractValidator<SubscriptionMonitoredItem> _monitoredItemValidator;
         private readonly int _batchSize;
@@ -41,13 +42,13 @@ namespace OMP.Connector.Application.Providers.Subscription
             ISubscriptionRepository subscriptionRepository,
             ILogger<CreateSubscriptionProvider> logger,
             IOptions<ConnectorConfiguration> connectorConfiguration,
-            IOpcMonitoredItemService opcMonitoredItemService,
+            IOpcMonitoredItemServiceFactory opcMonitoredItemServiceFactory,
             CreateSubscriptionsRequest command,
             TelemetryMessageMetadata messageMetadata,
             AbstractValidator<SubscriptionMonitoredItem> monitoredItemValidator) : base(command, connectorConfiguration, logger)
         {
             this._subscriptionRepository = subscriptionRepository;
-            this._opcMonitoredItemService = opcMonitoredItemService;
+            this.opcMonitoredItemServiceFactory = opcMonitoredItemServiceFactory;
             this._messageMetadata = messageMetadata;
             this._monitoredItemValidator = monitoredItemValidator;
             this._batchSize = this.Settings.OpcUa.SubscriptionBatchSize;
@@ -268,8 +269,8 @@ namespace OMP.Connector.Application.Providers.Subscription
 
         private MonitoredItem InitializeMonitoredItem(SubscriptionMonitoredItem monitoredItem, IComplexTypeSystem complexTypeSystem, TelemetryMessageMetadata telemetryMessageMetadata)
         {
-            this._opcMonitoredItemService.Initialize(monitoredItem, complexTypeSystem, telemetryMessageMetadata);
-            return this._opcMonitoredItemService as MonitoredItem;
+            var newMonitoredItem = opcMonitoredItemServiceFactory.Create(monitoredItem, complexTypeSystem, telemetryMessageMetadata);
+            return newMonitoredItem as MonitoredItem;
         }
     }
 }

--- a/src/Application/Services/OpcMonitoredItemServiceFactory.cs
+++ b/src/Application/Services/OpcMonitoredItemServiceFactory.cs
@@ -1,0 +1,42 @@
+﻿// SPDX-License-Identifier: MIT. 
+// Copyright Contributors to the Open Manufacturing Platform.
+
+using AutoMapper;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OMP.Connector.Domain.Configuration;
+using OMP.Connector.Domain.Models.Telemetry;
+using OMP.Connector.Domain.OpcUa.Services;
+using OMP.Connector.Domain.Schema;
+using OMP.Connector.Domain;
+
+namespace OMP.Connector.Application.Services
+{
+    public class OpcMonitoredItemServiceFactory : IOpcMonitoredItemServiceFactory
+    {
+        private ILogger<OpcMonitoredItemService> logger;
+        private IMapper mapper;
+        private IOptions<ConnectorConfiguration> connectorConfiguration;
+        private IMessageSender messageSender;
+
+        public OpcMonitoredItemServiceFactory(
+            IOptions<ConnectorConfiguration> connectorConfiguration,
+            IMessageSender messageSender,
+            IMapper mapper,
+            ILogger<OpcMonitoredItemService> logger
+            )
+        {
+            this.logger = logger;
+            this.mapper = mapper;
+            this.connectorConfiguration = connectorConfiguration;
+            this.messageSender = messageSender;
+        }
+
+        public IOpcMonitoredItemService Create(SubscriptionMonitoredItem monitoredItemCommand, IComplexTypeSystem complexTypeSystem, TelemetryMessageMetadata messageMetadata)
+        {
+            var monitoredItemService = new OpcMonitoredItemService(connectorConfiguration, messageSender, mapper, logger);
+            monitoredItemService.Initialize(monitoredItemCommand, complexTypeSystem, messageMetadata);
+            return monitoredItemService;
+        }
+    }
+}

--- a/src/Domain/OpcUa/Services/IOpcMonitoredItemServiceFactory.cs
+++ b/src/Domain/OpcUa/Services/IOpcMonitoredItemServiceFactory.cs
@@ -1,0 +1,13 @@
+﻿// SPDX-License-Identifier: MIT. 
+// Copyright Contributors to the Open Manufacturing Platform.
+
+using OMP.Connector.Domain.Models.Telemetry;
+using OMP.Connector.Domain.Schema;
+
+namespace OMP.Connector.Domain.OpcUa.Services
+{
+    public interface IOpcMonitoredItemServiceFactory
+    {
+        IOpcMonitoredItemService Create(SubscriptionMonitoredItem monitoredItemCommand, IComplexTypeSystem complexTypeSystem, TelemetryMessageMetadata messageMetadata);
+    }
+}


### PR DESCRIPTION
Incorrect initialization of monitored items caused only one monitored item to be added to a subscription.